### PR TITLE
Level up API

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -14,8 +14,10 @@ class Api::V1::ItemsController < ApplicationController
   end
 
   def index
+    @all = params[:all]
     @user = User.find_by_display_name(params[:display_name])
     @items = Item.find_all_by_poster_id(@user.id)
+    @filtered_items = created_on_or_after(@items) if params[:time]
   end
 
   def show
@@ -82,5 +84,12 @@ class Api::V1::ItemsController < ApplicationController
   def validate_token!
     user = User.find_by_api_key(params[:api_key])
     error(:forbidden) unless user
+  end
+
+  def created_on_or_after(items)
+    items.select do |item|
+      logger.info("#{item.created_at} >= #{params[:time]}")
+      item.created_at.to_s >= Time.parse(params[:time]).to_s
+    end
   end
 end

--- a/app/views/api/v1/items/index.json.jbuilder
+++ b/app/views/api/v1/items/index.json.jbuilder
@@ -19,6 +19,32 @@ json.items do |json|
       json.refeed "false"
       json.refeed_link ""
     end
+    if @all
+      json.all @user.items do |json, item|
+        json.(item, :post_type)
+        json.(item.post, :body) if item.post.message?
+        json.(item.post, :url, :description) if item.post.link? || item.post.image?
+        json.(item, :created_at)
+        json.(item, :id)
+        json.feed api_v1_items_url(@user.display_name)
+        json.link api_v1_item_url(@user.display_name, item.id)
+        json.refeed "false"
+        json.refeed_link ""
+      end
+    end
+    if @filtered_items
+      json.filtered @filtered_items do |json, item|
+        json.(item, :post_type)
+        json.(item.post, :body) if item.post.message?
+        json.(item.post, :url, :description) if item.post.link? || item.post.image?
+        json.(item, :created_at)
+        json.(item, :id)
+        json.feed api_v1_items_url(@user.display_name)
+        json.link api_v1_item_url(@user.display_name, item.id)
+        json.refeed "false"
+        json.refeed_link ""
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The items#index action now recognizes 2 new parameters: 'all' and 'time'. If the
'all' parameter is supplied you will find all of the users posts under 'all' in
the items (e.g parsed_response['items']['all']). The 'time' parameter will
filter the users items by creation time given a UTC time string, returning all
items created on or after that time, including refeeds.
